### PR TITLE
Update coverage tests to run tool as go source instead of running it …

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,7 +27,7 @@ jobs:
         run: go test ./... -coverprofile=./cover.out -covermode=atomic -coverpkg=./...
 
       - name: Generate coverage badge
-        uses: vladopajic/go-test-coverage@ebf1fb6f7267bd290a83cc16f535067b51fd1d0b # v2.15.0
+        uses: vladopajic/go-test-coverage/action/source@v2
         with:
           config: ./.testcoverage.yml
           git-branch: badges


### PR DESCRIPTION
…as binary from docker image